### PR TITLE
Skip stats update if bunny API scrape failed

### DIFF
--- a/bunnycdn_exporter.go
+++ b/bunnycdn_exporter.go
@@ -316,6 +316,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 		if err != nil {
 			log.Errorf("Unable to collect stats: %v", err)
 			e.totalErrors.Inc()
+			continue
 		}
 		aStatsObj = stats
 		for name, metric := range e.pullZoneMetrics {


### PR DESCRIPTION
When failing to scrape from Bunny CDN API, by this change, we skip updating the stats.
Without this change, we used to have `SIGSEGV` panics at the line `ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, extractFromMap(stats.BandwidthUsed), pullZone.Name)`