### PR TITLE
hotfix for changing bunnycdn api url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bunnycdn_exporter
 *.mprof
 *-stamp
 .vscode
+vendor/

--- a/LOGIC.md
+++ b/LOGIC.md
@@ -2,13 +2,13 @@
 CURL Command:
 
 # load pull zones
-curl --header "Content-Type: application/json"      --header "Accept: application/json"      --header "AccessKey: <API_KEY>"   'https://bunnycdn.com/api/pullzone' | jq
+curl --header "Content-Type: application/json"      --header "Accept: application/json"      --header "AccessKey: <API_KEY>"   'https://api.bunny.net/pullzone' | jq
 
 # load stats
-curl --header "Content-Type: application/json"      --header "Accept: application/json"      --header "AccessKey: <API_KEY>"   'https://bunnycdn.com/api/statistics?dateFrom=2019-05-01&dateTo=2019-05-10&pullZone=65109&serverZoneId=-1&loadErrors=true' | jq
+curl --header "Content-Type: application/json"      --header "Accept: application/json"      --header "AccessKey: <API_KEY>"   'https://api.bunny.net/statistics?dateFrom=2019-05-01&dateTo=2019-05-10&pullZone=65109&serverZoneId=-1&loadErrors=true' | jq
 
 URL:
-https://bunnycdn.com/api/statistics?
+https://api.bunny.net/statistics?
   dateFrom=2019-05-01&
   dateTo=2019-05-01&
   pullZone=65109&

--- a/bunnycdn_exporter.go
+++ b/bunnycdn_exporter.go
@@ -252,7 +252,7 @@ func rawGetStatistics(fetch func(path string) (io.ReadCloser, error), extraParam
 }
 
 func listPullZones(fetch func(path string) (io.ReadCloser, error)) ([]bunnyPullZone, error) {
-	// body, err := fetchHTTP("https://bunnycdn.com/api/pullzone", true, time.Seconds*5)
+	// body, err := fetchHTTP("https://api.bunny.net/api/pullzone", true, time.Seconds*5)
 	body, err := fetch("/pullzone")
 	if err != nil {
 		return nil, err
@@ -369,7 +369,7 @@ func main() {
 	var (
 		listenAddress  = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9584").String()
 		metricsPath    = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		bunnyAPIURI    = kingpin.Flag("bunnycdn.api-uri", "API URI on which to get stats from.").Default("https://bunnycdn.com/api").String()
+		bunnyAPIURI    = kingpin.Flag("bunnycdn.api-uri", "API URI on which to get stats from.").Default("https://api.bunny.net").String()
 		bunnyAPIKey    = kingpin.Flag("bunnycdn.api-key", "API key to connect to bunny.").Default(os.Getenv("BUNNYCDN_API_KEY")).String()
 		bunnySSLVerify = kingpin.Flag("bunnycdn.ssl-verify", "Flag that enables SSL certificate verification for the API URI").Default("true").Bool()
 		bunnyTimeout   = kingpin.Flag("bunnycdn.timeout", "Timeout for trying to get stats from BunnyCDN.").Default("10s").Duration()


### PR DESCRIPTION
Today we started to get 500err from `bunnycdn.com/api` because api url was changed. This hotfix change default url